### PR TITLE
I've implemented PDF export for individual Exposure Records.

### DIFF
--- a/app/templates/exposures/exposure_form.html
+++ b/app/templates/exposures/exposure_form.html
@@ -58,11 +58,14 @@
         {{ form.notes(class="form-control" + (" is-invalid" if form.notes.errors else ""), rows=3, cols=40) }}
         {% if form.notes.errors %}<div class="invalid-feedback">{% for error in form.notes.errors %}<span>{{ error }}</span><br>{% endfor %}</div>{% endif %}
     </div>
-    <div class="mb-3">
+    <div class="mb-3 mt-4"> {# Added mt-4 for spacing above button group #}
         {{ form.submit(class="btn btn-primary") }}
+        {% if exposure_id is defined and exposure_id is not none %}
+            <a href="{{ url_for('exposures.print_exposure_pdf', exposure_id=exposure_id) }}" class="btn btn-info ms-2" target="_blank">Print PDF</a>
+        {% endif %}
+        <a href="{{ url_for('exposures.list_exposures') }}" class="btn btn-outline-secondary ms-2">Back to List</a>
     </div>
 </form>
-        <p class="mt-4 text-center"><a href="{{ url_for('exposures.list_exposures') }}" class="btn btn-outline-secondary">Back to Exposure List</a></p>
     </div>
 </div>
 {% endblock %}

--- a/app/templates/exposures/exposures.html
+++ b/app/templates/exposures/exposures.html
@@ -5,7 +5,7 @@
 {% block content %}
 <h2>Manage Exposures</h2>
 {% if current_user.is_authenticated and current_user.role == 'admin' %}
-<p><a href="{{ url_for('add_exposure') }}" class="btn btn-primary mb-3">Add New Exposure Record</a></p>
+<p><a href="{{ url_for('exposures.add_exposure') }}" class="btn btn-primary mb-3">Add New Exposure Record</a></p>
 {% endif %}
 
 {% if exposures %}
@@ -40,6 +40,7 @@
                     <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Are you sure you want to delete this exposure record?');">Delete</button>
                 </form>
                 {% endif %}
+                <a href="{{ url_for('exposures.print_exposure_pdf', exposure_id=exposure.id) }}" class="btn btn-sm btn-outline-info ms-1" target="_blank" title="Print PDF">Print PDF</a>
             </td>
         </tr>
         {% endfor %}

--- a/app/templates/health_records/health_records.html
+++ b/app/templates/health_records/health_records.html
@@ -5,7 +5,7 @@
 {% block content %}
 <h2>Manage Health Records</h2>
 {% if current_user.is_authenticated and current_user.role == 'admin' %}
-<p><a href="{{ url_for('add_health_record') }}" class="btn btn-primary mb-3">Add New Health Record</a></p>
+<p><a href="{{ url_for('health_records.add_health_record') }}" class="btn btn-primary mb-3">Add New Health Record</a></p>
 {% endif %}
 
 {% if health_records %}

--- a/app/utils/pdf_generator.py
+++ b/app/utils/pdf_generator.py
@@ -1,0 +1,96 @@
+import io
+from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Table, TableStyle
+from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+from reportlab.lib.units import inch
+from reportlab.lib.enums import TA_CENTER, TA_LEFT, TA_JUSTIFY
+from reportlab.lib import colors
+from datetime import datetime # To format dates
+
+def generate_exposure_pdf(exposure_record):
+    buffer = io.BytesIO()
+    doc = SimpleDocTemplate(buffer,
+                            rightMargin=0.75*inch, leftMargin=0.75*inch,
+                            topMargin=1*inch, bottomMargin=1*inch,
+                            title=f"Exposure Record - ID {exposure_record.id}")
+
+    styles = getSampleStyleSheet()
+    # Custom styles
+    title_style = ParagraphStyle(name='TitleCustom', parent=styles['h1'], alignment=TA_CENTER, spaceAfter=0.3*inch, fontSize=16)
+    heading_style = ParagraphStyle(name='HeadingCustom', parent=styles['h2'], spaceAfter=0.1*inch, spaceBefore=0.2*inch, fontSize=14)
+    body_style = styles['BodyText']
+    body_style_bold_label = ParagraphStyle(name='BodyTextBoldLabel', parent=body_style, fontName='Helvetica-Bold')
+    body_style_justify = ParagraphStyle(name='BodyTextJustify', parent=styles['BodyText'], alignment=TA_JUSTIFY)
+
+    story = []
+
+    # Title
+    story.append(Paragraph(f"Occupational Exposure Record - ID: {exposure_record.id}", title_style))
+
+    # Employee and Hazard Info
+    story.append(Paragraph("Subject and Hazard Information", heading_style))
+    data_employee_hazard = [
+        [Paragraph("Employee:", body_style_bold_label), Paragraph(exposure_record.employee.name if exposure_record.employee else 'N/A', body_style)],
+        [Paragraph("Job Title:", body_style_bold_label), Paragraph(exposure_record.employee.job_title if exposure_record.employee else 'N/A', body_style)],
+        [Paragraph("Department:", body_style_bold_label), Paragraph(exposure_record.employee.department if exposure_record.employee else 'N/A', body_style)],
+        [Paragraph("Hazard:", body_style_bold_label), Paragraph(exposure_record.hazard.name if exposure_record.hazard else 'N/A', body_style)],
+        [Paragraph("Hazard Category:", body_style_bold_label), Paragraph(exposure_record.hazard.category if exposure_record.hazard else 'N/A', body_style)],
+    ]
+    table_eh = Table(data_employee_hazard, colWidths=[1.7*inch, 4.8*inch]) # Adjusted colWidths
+    table_eh.setStyle(TableStyle([
+        ('VALIGN', (0,0), (-1,-1), 'TOP'),
+        ('LEFTPADDING', (0,0), (-1,-1), 0), # Less padding for labels
+        ('GRID', (0,0), (-1,-1), 0.5, colors.lightgrey),
+    ]))
+    story.append(table_eh)
+    story.append(Spacer(1, 0.2*inch))
+
+    # Exposure Details
+    story.append(Paragraph("Exposure Details", heading_style))
+    exposure_date_str = exposure_record.date.strftime('%Y-%m-%d %H:%M') if exposure_record.date else 'N/A'
+    hazard_unit_str = exposure_record.hazard.unit if exposure_record.hazard else ''
+    duration_str = f"{exposure_record.duration} hours" if exposure_record.duration is not None else 'N/A'
+
+    data_exposure = [
+        [Paragraph("Date of Exposure:", body_style_bold_label), Paragraph(exposure_date_str, body_style)],
+        [Paragraph("Exposure Level:", body_style_bold_label), Paragraph(f"{exposure_record.exposure_level} {hazard_unit_str}", body_style)],
+        [Paragraph("Duration:", body_style_bold_label), Paragraph(duration_str, body_style)],
+        [Paragraph("Location:", body_style_bold_label), Paragraph(exposure_record.location if exposure_record.location else 'N/A', body_style)],
+    ]
+    table_exp = Table(data_exposure, colWidths=[1.7*inch, 4.8*inch])
+    table_exp.setStyle(TableStyle([
+        ('VALIGN', (0,0), (-1,-1), 'TOP'),
+        ('LEFTPADDING', (0,0), (-1,-1), 0),
+        ('GRID', (0,0), (-1,-1), 0.5, colors.lightgrey),
+    ]))
+    story.append(table_exp)
+    story.append(Spacer(1, 0.2*inch))
+
+    # Hazard Information (Description and Safety Measures)
+    if exposure_record.hazard:
+        if exposure_record.hazard.description or exposure_record.hazard.safety_measures:
+            story.append(Paragraph("Hazard Information", heading_style))
+            if exposure_record.hazard.description:
+                story.append(Paragraph("<b>Description:</b>", body_style)) # Using <b> for inline bold
+                story.append(Paragraph(exposure_record.hazard.description, body_style_justify))
+                story.append(Spacer(1, 0.05*inch))
+            if exposure_record.hazard.safety_measures:
+                story.append(Paragraph("<b>Control Measures:</b>", body_style))
+                story.append(Paragraph(exposure_record.hazard.safety_measures, body_style_justify))
+            story.append(Spacer(1, 0.2*inch))
+
+    # Notes
+    if exposure_record.notes:
+        story.append(Paragraph("Exposure Notes", heading_style))
+        story.append(Paragraph(exposure_record.notes, body_style_justify))
+        story.append(Spacer(1, 0.2*inch))
+
+    # Footer Info
+    story.append(Paragraph(f"Recorded By: {exposure_record.recorder.username if exposure_record.recorder else 'N/A'}", body_style))
+    created_at_str = exposure_record.created_at.strftime('%Y-%m-%d %H:%M:%S') if exposure_record.created_at else 'N/A'
+    story.append(Paragraph(f"Record Created At: {created_at_str} UTC", body_style)) # Assuming UTC
+    story.append(Paragraph(f"Report Generated: {datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')} UTC", body_style))
+
+    doc.build(story)
+    pdf_value = buffer.getvalue()
+    buffer.close()
+    return pdf_value


### PR DESCRIPTION
This feature allows you to generate a PDF document for any specific exposure record.

Key changes:
- I created `app/utils/pdf_generator.py` with a function `generate_exposure_pdf(exposure_record)` using ReportLab to construct a detailed PDF. The PDF includes information about the employee, hazard (name, category, description, safety measures), exposure details (level, duration, date, location, notes), and record metadata (recorded by, creation date, report generation date).
- I added a new route `exposures.print_exposure_pdf` (at `/exposures/<int:exposure_id>/print_pdf`) in `app/exposures/routes.py`. This route is protected by `@login_required`, fetches the exposure, calls the PDF utility, and serves the PDF with appropriate `application/pdf` headers and an `inline` content disposition. It also includes error handling and logging.
- I added "Print PDF" buttons (styled with Bootstrap, opening in a new tab) to:
    - Each row in the exposure list page (`app/templates/exposures/exposures.html`).
    - The exposure edit form page (`app/templates/exposures/exposure_form.html`) for existing records.
- I added comprehensive unit tests in `tests/test_exposure_crud.py` for the PDF generation route, covering authentication, successful PDF generation (headers, content), 404 errors, and error handling during PDF creation (using mocking).